### PR TITLE
ensured top level JWT module is used

### DIFF
--- a/lib/omniauth/strategies/azure_oauth2.rb
+++ b/lib/omniauth/strategies/azure_oauth2.rb
@@ -53,7 +53,7 @@ module OmniAuth
 
       def raw_info
         # it's all here in JWT http://msdn.microsoft.com/en-us/library/azure/dn195587.aspx
-        @raw_info ||= JWT.decode(access_token.token, nil, false).first
+        @raw_info ||= ::JWT.decode(access_token.token, nil, false).first
       end
 
     end

--- a/spec/omniauth/strategies/azure_oauth2_spec.rb
+++ b/spec/omniauth/strategies/azure_oauth2_spec.rb
@@ -1,6 +1,12 @@
 require 'spec_helper'
 require 'omniauth-azure-oauth2'
 
+module OmniAuth
+  module Strategies
+    module JWT; end
+  end
+end
+
 describe OmniAuth::Strategies::AzureOauth2 do
   let(:request) { double('Request', :params => {}, :cookies => {}, :env => {}) }
   let(:app) {
@@ -125,7 +131,7 @@ describe OmniAuth::Strategies::AzureOauth2 do
     end
 
   end
-  
+
   describe 'dynamic common configuration' do
     let(:provider_klass) {
       Class.new {
@@ -154,6 +160,30 @@ describe OmniAuth::Strategies::AzureOauth2 do
       it 'has correct token url' do
         expect(subject.client.options[:token_url]).to eql('https://login.windows.net/common/oauth2/token')
       end
+    end
+  end
+
+  describe "raw_info" do
+    subject do
+      OmniAuth::Strategies::AzureOauth2.new(app, {client_id: 'id', client_secret: 'secret'})
+    end
+
+    let(:token) do
+      JWT.encode({"some" => "payload"}, "secret")
+    end
+
+    let(:access_token) do
+      double(:token => token)
+    end
+
+    before :each do
+      allow(subject).to receive(:access_token) { access_token }
+    end
+
+    it "does not clash if JWT strategy is used" do
+      expect do
+        subject.info
+      end.to_not raise_error
     end
   end
 end


### PR DESCRIPTION
The call to `JWT.decode` fails if you are using [omniauth-jwt](https://github.com/mbleigh/omniauth-jwt) due to namespace conflicts.

Tobias