### PR TITLE
Fix name and add nickname to Auth Hash Schema

### DIFF
--- a/lib/omniauth/strategies/azure_oauth2.rb
+++ b/lib/omniauth/strategies/azure_oauth2.rb
@@ -42,7 +42,8 @@ module OmniAuth
 
       info do
         {
-          name: raw_info['unique_name'],
+          name: raw_info['name'],
+          nickname: raw_info['unique_name'],
           first_name: raw_info['given_name'],
           last_name: raw_info['family_name'],
           email: raw_info['email'] || raw_info['upn'],


### PR DESCRIPTION
[Auth Hash Schema (1.0 and Later)](https://github.com/intridea/omniauth/wiki/Auth-Hash-Schema#schema-10-and-later) states name should be:
"The best display name known to the strategy. Usually a concatenation
of first and last name, but may also be an arbitrary designator or
nickname for some strategies"

Azure sends "name" which is displayName in (on-premise) AD. Use that
as name and "unique_name" as nickname.