### PR TITLE
Add tenant id in info

### DIFF
--- a/lib/omniauth/strategies/azure_oauth2.rb
+++ b/lib/omniauth/strategies/azure_oauth2.rb
@@ -47,7 +47,8 @@ module OmniAuth
           first_name: raw_info['given_name'],
           last_name: raw_info['family_name'],
           email: raw_info['email'] || raw_info['upn'],
-          oid: raw_info['oid']
+          oid: raw_info['oid'],
+          tid: raw_info['tid']
         }
       end
 


### PR DESCRIPTION
Add tenant id to info, so that it can be used in multi-tenant applications to query things like directories