### PR TITLE
Support Office 365 Germany

### DIFF
--- a/lib/omniauth/strategies/azure_oauth2.rb
+++ b/lib/omniauth/strategies/azure_oauth2.rb
@@ -20,7 +20,7 @@ module OmniAuth
         if options.tenant_provider
           provider = options.tenant_provider.new(self)
         else
-          provider = options  # if pass has to config, get mapped right on to ptions
+          provider = options  # if pass has to config, get mapped right on to options
         end
 
         options.client_id = provider.client_id

--- a/lib/omniauth/strategies/azure_oauth2.rb
+++ b/lib/omniauth/strategies/azure_oauth2.rb
@@ -13,7 +13,7 @@ module OmniAuth
       # AD resource identifier
       option :resource, '00000002-0000-0000-c000-000000000000'
 
-      # tenant_provider must return client_id, client_secret and optionally tenant_id
+      # tenant_provider must return client_id, client_secret and optionally tenant_id and base_azure_url
       args [:tenant_provider]
 
       def client
@@ -27,11 +27,13 @@ module OmniAuth
         options.client_secret = provider.client_secret
         options.tenant_id =
           provider.respond_to?(:tenant_id) ? provider.tenant_id : 'common'
+        options.base_azure_url = 
+          provider.respond_to?(:base_azure_url) ? provider.base_azure_url : BASE_AZURE_URL
 
         options.authorize_params.domain_hint = provider.domain_hint if provider.respond_to?(:domain_hint) && provider.domain_hint
         options.authorize_params.prompt = request.params['prompt'] if request.params['prompt']
-        options.client_options.authorize_url = "#{BASE_AZURE_URL}/#{options.tenant_id}/oauth2/authorize"
-        options.client_options.token_url = "#{BASE_AZURE_URL}/#{options.tenant_id}/oauth2/token"
+        options.client_options.authorize_url = "#{options.base_azure_url}/#{options.tenant_id}/oauth2/authorize"
+        options.client_options.token_url = "#{options.base_azure_url}/#{options.tenant_id}/oauth2/token"
 
         options.token_params.resource = options.resource
         super

--- a/spec/omniauth/strategies/azure_oauth2_spec.rb
+++ b/spec/omniauth/strategies/azure_oauth2_spec.rb
@@ -64,6 +64,46 @@ describe OmniAuth::Strategies::AzureOauth2 do
 
   end
 
+  describe 'static configuration - german' do
+    let(:options) { @options || {} }
+    subject do
+      OmniAuth::Strategies::AzureOauth2.new(app, {client_id: 'id', client_secret: 'secret', tenant_id: 'tenant', base_azure_url: 'https://login.microsoftonline.de'}.merge(options))
+    end
+  
+    describe '#client' do
+      it 'has correct authorize url' do
+        allow(subject).to receive(:request) { request }
+        expect(subject.client.options[:authorize_url]).to eql('https://login.microsoftonline.de/tenant/oauth2/authorize')
+      end
+  
+      it 'has correct authorize params' do
+        allow(subject).to receive(:request) { request }
+        subject.client
+        expect(subject.authorize_params[:domain_hint]).to be_nil
+      end
+  
+      it 'has correct token url' do
+        allow(subject).to receive(:request) { request }
+        expect(subject.client.options[:token_url]).to eql('https://login.microsoftonline.de/tenant/oauth2/token')
+      end
+  
+      it 'has correct token params' do
+        allow(subject).to receive(:request) { request }
+        subject.client
+        expect(subject.token_params[:resource]).to eql('00000002-0000-0000-c000-000000000000')
+      end
+  
+      describe "overrides" do
+        it 'should override domain_hint' do
+          @options = {domain_hint: 'hint'}
+          allow(subject).to receive(:request) { request }
+          subject.client
+          expect(subject.authorize_params[:domain_hint]).to eql('hint')
+        end
+      end
+    end
+  end
+  
   describe 'static common configuration' do
     let(:options) { @options || {} }
     subject do
@@ -143,6 +183,69 @@ describe OmniAuth::Strategies::AzureOauth2 do
       # end
     end
 
+  end
+
+  describe 'dynamic configuration - german' do
+    let(:provider_klass) {
+      Class.new {
+        def initialize(strategy)
+        end
+  
+        def client_id
+          'id'
+        end
+  
+        def client_secret
+          'secret'
+        end
+  
+        def tenant_id
+          'tenant'
+        end
+        
+        def base_azure_url
+          'https://login.microsoftonline.de'
+        end
+      }
+    }
+  
+    subject do
+      OmniAuth::Strategies::AzureOauth2.new(app, provider_klass)
+    end
+  
+    before do
+      allow(subject).to receive(:request) { request }
+    end
+  
+    describe '#client' do
+      it 'has correct authorize url' do
+        expect(subject.client.options[:authorize_url]).to eql('https://login.microsoftonline.de/tenant/oauth2/authorize')
+      end
+  
+      it 'has correct authorize params' do
+        subject.client
+        expect(subject.authorize_params[:domain_hint]).to be_nil
+      end
+  
+      it 'has correct token url' do
+        expect(subject.client.options[:token_url]).to eql('https://login.microsoftonline.de/tenant/oauth2/token')
+      end
+  
+      it 'has correct token params' do
+        subject.client
+        expect(subject.token_params[:resource]).to eql('00000002-0000-0000-c000-000000000000')
+      end
+  
+      # todo: how to get this working?
+      # describe "overrides" do
+      #   it 'should override domain_hint' do
+      #     provider_klass.domain_hint = 'hint'
+      #     subject.client
+      #     expect(subject.authorize_params[:domain_hint]).to eql('hint')
+      #   end
+      # end
+    end
+  
   end
 
   describe 'dynamic common configuration' do


### PR DESCRIPTION
This pull request solves issue #14 by asking the tenant provider for the base azure url, making it configurable. If the tenant provider doesn't provide the url, it defaults to the current https://login.microsoftonline.com, keeping the current behavior as a fallback.