### PR TITLE
Fix creating a client when there is no live request

### DIFF
--- a/lib/omniauth/strategies/azure_oauth2.rb
+++ b/lib/omniauth/strategies/azure_oauth2.rb
@@ -31,7 +31,7 @@ module OmniAuth
           provider.respond_to?(:base_azure_url) ? provider.base_azure_url : BASE_AZURE_URL
 
         options.authorize_params.domain_hint = provider.domain_hint if provider.respond_to?(:domain_hint) && provider.domain_hint
-        options.authorize_params.prompt = request.params['prompt'] if request.params['prompt']
+        options.authorize_params.prompt = request.params['prompt'] if defined? request && request.params['prompt']
         options.client_options.authorize_url = "#{options.base_azure_url}/#{options.tenant_id}/oauth2/authorize"
         options.client_options.token_url = "#{options.base_azure_url}/#{options.tenant_id}/oauth2/token"
 


### PR DESCRIPTION
Hi all, I use the oauth2 strategy client from this project to help refresh tokens in my project. I know that's not a supported use of the client necessarily, but I was curious why this line existed anyway, because creating a client should have nothing to do with processing an ongoing request. Is there a way to factor this beahvior elsewhere?