### PR TITLE
allow to pass custom resource

### DIFF
--- a/lib/omniauth/strategies/azure_oauth2.rb
+++ b/lib/omniauth/strategies/azure_oauth2.rb
@@ -54,8 +54,8 @@ module OmniAuth
       end
       
       def token_params
-        resource = request.env.dig('omniauth.params', 'azure_resource') || options.resource
-        super.merge(resource: resource)
+        azure_resource = request.env['omniauth.params'] && request.env['omniauth.params']['azure_resource']
+        super.merge(resource: azure_resource || options.resource)
       end
 
       def callback_url

--- a/lib/omniauth/strategies/azure_oauth2.rb
+++ b/lib/omniauth/strategies/azure_oauth2.rb
@@ -34,8 +34,6 @@ module OmniAuth
         options.authorize_params.prompt = request.params['prompt'] if request.params['prompt']
         options.client_options.authorize_url = "#{options.base_azure_url}/#{options.tenant_id}/oauth2/authorize"
         options.client_options.token_url = "#{options.base_azure_url}/#{options.tenant_id}/oauth2/token"
-
-        options.token_params.resource = options.resource
         super
       end
 
@@ -53,6 +51,11 @@ module OmniAuth
           oid: raw_info['oid'],
           tid: raw_info['tid']
         }
+      end
+      
+      def token_params
+        resource = request.env.dig('omniauth.params', 'azure_resource') || options.resource
+        super.merge(resource: resource)
       end
 
       def callback_url

--- a/spec/omniauth/strategies/azure_oauth2_spec.rb
+++ b/spec/omniauth/strategies/azure_oauth2_spec.rb
@@ -46,10 +46,24 @@ describe OmniAuth::Strategies::AzureOauth2 do
         expect(subject.client.options[:token_url]).to eql('https://login.microsoftonline.com/tenant/oauth2/token')
       end
 
-      it 'has correct token params' do
-        allow(subject).to receive(:request) { request }
-        subject.client
-        expect(subject.token_params[:resource]).to eql('00000002-0000-0000-c000-000000000000')
+      context 'when token params' do
+        before do
+          allow(subject).to receive(:request) { request }
+          subject.client
+        end
+
+        it 'has default resource' do
+          expect(subject.token_params[:resource]).to eq '00000002-0000-0000-c000-000000000000'
+        end
+
+        context 'when custom crm url' do
+          let(:crm_url) { 'https//mydomain.crm.dynamics.com/' }
+
+          it 'has resource from url params' do
+            request.env['omniauth.params'] = { 'azure_resource' => crm_url }
+            expect(subject.token_params[:resource]).to eq crm_url
+          end
+        end
       end
 
       describe "overrides" do

--- a/spec/omniauth/strategies/azure_oauth2_spec.rb
+++ b/spec/omniauth/strategies/azure_oauth2_spec.rb
@@ -46,26 +46,6 @@ describe OmniAuth::Strategies::AzureOauth2 do
         expect(subject.client.options[:token_url]).to eql('https://login.microsoftonline.com/tenant/oauth2/token')
       end
 
-      context 'when token params' do
-        before do
-          allow(subject).to receive(:request) { request }
-          subject.client
-        end
-
-        it 'has default resource' do
-          expect(subject.token_params[:resource]).to eq '00000002-0000-0000-c000-000000000000'
-        end
-
-        context 'when custom crm url' do
-          let(:crm_url) { 'https//mydomain.crm.dynamics.com/' }
-
-          it 'has resource from url params' do
-            request.env['omniauth.params'] = { 'azure_resource' => crm_url }
-            expect(subject.token_params[:resource]).to eq crm_url
-          end
-        end
-      end
-
       describe "overrides" do
         it 'should override domain_hint' do
           @options = {domain_hint: 'hint'}
@@ -319,6 +299,30 @@ describe OmniAuth::Strategies::AzureOauth2 do
       expect do
         subject.info
       end.to_not raise_error
+    end
+  end
+
+  describe 'token_params' do
+    let(:strategy) { OmniAuth::Strategies::AzureOauth2.new(app, client_id: 'id', client_secret: 'secret') }
+    let(:request)  { double('Request', env: env) }
+    let(:env)      { {} }
+
+    subject { strategy.token_params }
+
+    before { allow(strategy).to receive(:request).and_return request }
+
+    it { is_expected.to be_a OmniAuth::Strategy::Options }
+    it 'has default resource' do
+      expect(subject.resource).to eq '00000002-0000-0000-c000-000000000000'
+    end
+
+    context 'when custom crm url' do
+      let(:crm_url) { 'https://mydomain.crm.dynamics.com/' }
+      let(:env)     { { 'omniauth.params' => { 'azure_resource' => crm_url } } }
+
+      it 'has resource from url params' do
+        expect(subject.resource).to eq crm_url
+      end
     end
   end
 end


### PR DESCRIPTION
Hey guys, what do you think about that?
I am working on Ms Dynamics integration and need to pass a custom resource url to be able to access dynamics resources. 
In case below url to start oauth should look like:
`example.com/authorize?azure_resource=https://mydomain.crm.dynamics.com`
