### PR TITLE
updated jwt version dependency

### DIFF
--- a/omniauth-azure-oauth2.gemspec
+++ b/omniauth-azure-oauth2.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.license       = "MIT"
 
   gem.add_dependency 'omniauth', '~> 1.0'
-  gem.add_dependency 'jwt', '~> 1.0'
+  gem.add_dependency 'jwt', ['>= 1.0', '< 3.0']
 
   gem.add_runtime_dependency 'omniauth-oauth2', '~> 1.4'
 


### PR DESCRIPTION
Updated the version of jwt that the gem is dependent on. Patterned the range of version dependency from the [oauth2 gem](https://github.com/oauth-xx/oauth2/blob/68fac86d36a0abe65d3a656ad0dc49fe11f65fea/oauth2.gemspec#L9)