### PR TITLE
Azure v2 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,25 @@ use OmniAuth::Builder do
 end
 ```
 
+## Azure v2 Endpoints
+
+The Azure `v1` endpoints are used by default. To use the `v2` endpoints set the `v2` option to `true`. Ex:
+
+```ruby
+use OmniAuth::Builder do
+  provider :azure_oauth2,
+    {
+      client_id: ENV['AZURE_CLIENT_ID'],
+      client_secret: ENV['AZURE_CLIENT_SECRET'],
+      tenant_id: ENV['AZURE_TENANT_ID'],
+      v2: true
+    }
+end
+```
+
+A scope must be set for the `v2` endpoints to work properly. The default scope is `User.Read`, which is automatically set.
+To use different scopes, set the scope option in the config. It currently isn't designed to be dynamic.
+
 ## Contributing
 
 1. Fork it

--- a/spec/omniauth/strategies/azure_oauth2_spec.rb
+++ b/spec/omniauth/strategies/azure_oauth2_spec.rb
@@ -119,6 +119,83 @@ describe OmniAuth::Strategies::AzureOauth2 do
     end
   end
 
+  describe 'static common configuration v2' do
+    let(:options) { @options || {} }
+    subject do
+      OmniAuth::Strategies::AzureOauth2.new(app, {client_id: 'id', client_secret: 'secret', v2: true}.merge(options))
+    end
+
+    before do
+      allow(subject).to receive(:request) { request }
+    end
+
+    describe '#client' do
+      it 'has correct authorize url' do
+        expect(subject.client.options[:authorize_url]).to eql('https://login.microsoftonline.com/common/oauth2/v2.0/authorize')
+      end
+
+      it 'has correct token url' do
+        expect(subject.client.options[:token_url]).to eql('https://login.microsoftonline.com/common/oauth2/v2.0/token')
+      end
+
+      it 'has correct authorize params' do
+        subject.client
+        expect(subject.authorize_params[:scope]).to eql('User.Read')
+        expect(subject.authorize_params[:resource]).to be_nil
+      end
+
+      it 'has correct token params' do
+        subject.client
+        expect(subject.token_params[:scope]).to eql('User.Read')
+        expect(subject.token_params[:resource]).to be_nil
+      end
+
+      it 'has correct uid claim' do
+        subject.client
+        expect(subject.options[:uid_claim]).to eql('sub')
+      end
+    end
+  end
+
+  describe 'static custom configuration v2' do
+    let(:options) { @options || {} }
+    subject do
+      OmniAuth::Strategies::AzureOauth2.new(app, {client_id: 'id', client_secret: 'secret', v2: true, uid_claim: 'oid'}.merge(options))
+    end
+
+    before do
+      allow(subject).to receive(:request) { request }
+    end
+
+    describe '#client' do
+      it 'has correct authorize url' do
+        expect(subject.client.options[:authorize_url]).to eql('https://login.microsoftonline.com/common/oauth2/v2.0/authorize')
+      end
+
+      it 'has correct token url' do
+        expect(subject.client.options[:token_url]).to eql('https://login.microsoftonline.com/common/oauth2/v2.0/token')
+      end
+
+      it 'has correct authorize params' do
+        subject.client
+        puts subject.authorize_params
+        expect(subject.authorize_params[:scope]).to eql('User.Read')
+        expect(subject.authorize_params[:resource]).to be_nil
+      end
+
+      it 'has correct token params' do
+        subject.client
+        expect(subject.token_params[:scope]).to eql('User.Read')
+        expect(subject.token_params[:resource]).to be_nil
+      end
+
+      it 'has correct uid claim' do
+        subject.client
+        expect(subject.options[:uid_claim]).to eql('oid')
+      end
+    end
+  end
+
   describe 'dynamic configuration' do
     let(:provider_klass) {
       Class.new {
@@ -277,6 +354,123 @@ describe OmniAuth::Strategies::AzureOauth2 do
 
       it 'has correct token url' do
         expect(subject.client.options[:token_url]).to eql('https://login.microsoftonline.com/common/oauth2/token')
+      end
+    end
+  end
+
+  describe 'dynamic common configuration v2' do
+    let(:provider_klass) {
+      Class.new {
+        def initialize(strategy)
+        end
+
+        def client_id
+          'id'
+        end
+
+        def client_secret
+          'secret'
+        end
+
+        def v2
+          true
+        end
+      }
+    }
+
+    subject do
+      OmniAuth::Strategies::AzureOauth2.new(app, provider_klass)
+    end
+
+    before do
+      allow(subject).to receive(:request) { request }
+    end
+
+    describe '#client' do
+      it 'has correct authorize url' do
+        expect(subject.client.options[:authorize_url]).to eql('https://login.microsoftonline.com/common/oauth2/v2.0/authorize')
+      end
+
+      it 'has correct token url' do
+        expect(subject.client.options[:token_url]).to eql('https://login.microsoftonline.com/common/oauth2/v2.0/token')
+      end
+
+      it 'has correct authorize params' do
+        subject.client
+        expect(subject.authorize_params[:scope]).to eql('User.Read')
+        expect(subject.authorize_params[:resource]).to be_nil
+      end
+
+      it 'has correct token params' do
+        subject.client
+        expect(subject.token_params[:scope]).to eql('User.Read')
+        expect(subject.token_params[:resource]).to be_nil
+      end
+
+      it 'has correct uid claim' do
+        subject.client
+        expect(subject.options[:uid_claim]).to eql('sub')
+      end
+    end
+  end
+
+  describe 'dynamic custom configuration v2' do
+    let(:provider_klass) {
+      Class.new {
+        def initialize(strategy)
+        end
+
+        def client_id
+          'id'
+        end
+
+        def client_secret
+          'secret'
+        end
+
+        def v2
+          true
+        end
+
+        def uid_claim
+          'oid'
+        end
+      }
+    }
+
+    subject do
+      OmniAuth::Strategies::AzureOauth2.new(app, provider_klass)
+    end
+
+    before do
+      allow(subject).to receive(:request) { request }
+    end
+
+    describe '#client' do
+      it 'has correct authorize url' do
+        expect(subject.client.options[:authorize_url]).to eql('https://login.microsoftonline.com/common/oauth2/v2.0/authorize')
+      end
+
+      it 'has correct token url' do
+        expect(subject.client.options[:token_url]).to eql('https://login.microsoftonline.com/common/oauth2/v2.0/token')
+      end
+
+      it 'has correct authorize params' do
+        subject.client
+        puts subject.authorize_params
+        expect(subject.authorize_params[:scope]).to eql('User.Read')
+        expect(subject.authorize_params[:resource]).to be_nil
+      end
+
+      it 'has correct token params' do
+        subject.client
+        expect(subject.token_params[:scope]).to eql('User.Read')
+        expect(subject.token_params[:resource]).to be_nil
+      end
+
+      it 'has correct uid claim' do
+        subject.client
+        expect(subject.options[:uid_claim]).to eql('oid')
       end
     end
   end


### PR DESCRIPTION
This adds support for the Azure `v2` endpoints. My use case is for GitLab and this works when I manually change the `lib` file. I have added corresponding tests.

I have also added an optional change to the claim used for a unique ID. When using the `sub` claim (which is the most sensible for most cases) it fails to authenticate the same user because the `sub` is different between the two versions. I use the `oid` claim in GitLab and change the user's provider identifier to be this value, which is available in AAD.

Note: I am not very familiar with Ruby so it is likely I have not followed best practices for the (very little) code I added. Please let me know if I should change anything.